### PR TITLE
Split creating group to two steps

### DIFF
--- a/powerscale/helper/user_group_helper.go
+++ b/powerscale/helper/user_group_helper.go
@@ -261,21 +261,6 @@ func CreateUserGroup(ctx context.Context, client *client.Client, plan *models.Us
 		body.Sid = plan.SID.ValueStringPointer()
 	}
 
-	for _, m := range plan.Users.Elements() {
-		name := strings.Trim(m.String(), "\"")
-		body.Members = append(body.Members, powerscale.V1AuthAccessAccessItemFileGroup{Name: &name})
-	}
-
-	for _, m := range plan.Groups.Elements() {
-		name := strings.Trim(m.String(), "\"")
-		body.Members = append(body.Members, powerscale.V1AuthAccessAccessItemFileGroup{Name: &name})
-	}
-
-	for _, m := range plan.WellKnowns.Elements() {
-		name := getWellKnownName(strings.Trim(m.String(), "\""))
-		body.Members = append(body.Members, powerscale.V1AuthAccessAccessItemFileGroup{Name: &name})
-	}
-
 	createParam = createParam.V1AuthGroup(*body)
 	if _, _, err := createParam.Execute(); err != nil {
 		errStr := constants.CreateUserGroupErrorMsg + "with error: "

--- a/powerscale/provider/user_group_resource.go
+++ b/powerscale/provider/user_group_resource.go
@@ -209,6 +209,11 @@ func (r *UserGroupResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// add user group members
+	if diags := helper.UpdateUserGroupMembers(ctx, r.client, &models.UserGroupResourceModel{}, &plan); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+	}
+
 	if diags := helper.UpdateUserGroupRoles(ctx, r.client, &models.UserGroupResourceModel{}, &plan); diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 	}

--- a/powerscale/provider/user_group_resource_test.go
+++ b/powerscale/provider/user_group_resource_test.go
@@ -89,7 +89,7 @@ func TestAccUserGroupResourceCreateErr(t *testing.T) {
 			// Create Error testing
 			{
 				Config:      ProviderConfig + userGroupErrCreateResourceConfig,
-				ExpectError: regexp.MustCompile(`.*Error creating the User Group*.`),
+				ExpectError: regexp.MustCompile(`.*Could not add member to user group*.`),
 			},
 		},
 	})


### PR DESCRIPTION
# Description
PowerScale API of creating user group is not working as expected:
As the screenshot shown, When creating group with one invalid member in POST body, it returns 500 error;
But even it throws 500 exception, the group is still created in OneFS, which is beyond expectation.
The is actual behavior of PowerScale API.
![image](https://github.com/dell/terraform-provider-powerscale/assets/88763781/b0408f7f-2d4f-4658-939a-8abb425f5b3b)

In that case, terraform cannot manage this resource, user need to delete it manually. We need to fix a solution to get around this.
Solution to solve this create API issue --> Split creating group into two steps:
 - create user group with no members;
 - add members to user group.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### RESOURCE OR DATASOURCE NAME
User Group Resource

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests

All at and ut for user groups are Passed.
![image](https://github.com/dell/terraform-provider-powerscale/assets/88763781/7be06442-959e-4f51-9d05-96ca1f35bae6)
