### PR TITLE
Add prechecks for create and update params for AD

### DIFF
--- a/powerscale/helper/ads_provider_helper.go
+++ b/powerscale/helper/ads_provider_helper.go
@@ -64,3 +64,27 @@ func DeleteAdsProvider(ctx context.Context, client *client.Client, adsID string)
 	_, err := client.PscaleOpenAPIClient.AuthApi.DeleteAuthv14ProvidersAdsById(ctx, adsID).Execute()
 	return err
 }
+
+// IsCreateAdsProviderParamInvalid Verify if create params contain params only for updating
+func IsCreateAdsProviderParamInvalid(plan models.AdsProviderResourceModel) bool {
+	if !plan.DomainController.IsNull() ||
+		!plan.ResetSchannel.IsNull() ||
+		!plan.Spns.IsUnknown() {
+		return true
+	}
+	return false
+}
+
+// IsUpdateAdsProviderParamInvalid Verify if update params contain params only for creating
+func IsUpdateAdsProviderParamInvalid(plan models.AdsProviderResourceModel, state models.AdsProviderResourceModel) bool {
+	if (!plan.DNSDomain.IsNull() && !state.DNSDomain.Equal(plan.DNSDomain)) ||
+		(!plan.Groupnet.IsUnknown() && !state.Groupnet.Equal(plan.Groupnet)) ||
+		(!plan.Instance.IsNull() && !state.Instance.Equal(plan.Instance)) ||
+		(!plan.KerberosHdfsSpn.IsNull() && !state.KerberosHdfsSpn.Equal(plan.KerberosHdfsSpn)) ||
+		(!plan.KerberosNfsSpn.IsNull() && !state.KerberosNfsSpn.Equal(plan.KerberosNfsSpn)) ||
+		(!plan.MachineAccount.IsUnknown() && !state.MachineAccount.Equal(plan.MachineAccount)) ||
+		(!plan.OrganizationalUnit.IsNull() && !state.OrganizationalUnit.Equal(plan.OrganizationalUnit)) {
+		return true
+	}
+	return false
+}

--- a/powerscale/helper/nfs_export_helper.go
+++ b/powerscale/helper/nfs_export_helper.go
@@ -209,7 +209,7 @@ func FilterExports(paths []types.String, ids []types.Int64, exports []powerscale
 
 // ResolvePersonaDiff implement state
 // For nfs export persona info, response may only contain UID while type/username is given
-// Need to manually copy plan info to state, or state would keep the type/username as null, which is inconsistent
+// Need to manually copy plan info to state, or state would keep the type/username as null, which is inconsistent.
 func ResolvePersonaDiff(ctx context.Context, plan models.NfsExportResource, state *models.NfsExportResource) {
 	state.MapAll = assignKnownObjectToUnknown(ctx, plan.MapAll, state.MapAll)
 	state.MapFailure = assignKnownObjectToUnknown(ctx, plan.MapAll, state.MapAll)

--- a/powerscale/provider/ads_provider_resource_test.go
+++ b/powerscale/provider/ads_provider_resource_test.go
@@ -154,6 +154,10 @@ func TestAccAdsProviderResourceErrorUpdate(t *testing.T) {
 				Config:      ProviderConfig + AdsProviderInvalidResourceConfig,
 				ExpectError: regexp.MustCompile(".*Bad Request*."),
 			},
+			{
+				Config:      ProviderConfig + AdsProviderUpdatePreCheckConfig,
+				ExpectError: regexp.MustCompile(".*Should not provide parameters for creating*."),
+			},
 		},
 	})
 }
@@ -166,6 +170,10 @@ func TestAccAdsProviderResourceErrorCreate(t *testing.T) {
 			{
 				Config:      ProviderConfig + AdsProviderInvalidResourceConfig,
 				ExpectError: regexp.MustCompile(".*Bad Request*."),
+			},
+			{
+				Config:      ProviderConfig + AdsProviderCreatePreCheckConfig,
+				ExpectError: regexp.MustCompile(".*Should not provide parameters for updating*."),
 			},
 		},
 	})
@@ -244,6 +252,15 @@ resource "powerscale_adsprovider" "ads_test" {
 }
 `, adsName)
 
+var AdsProviderCreatePreCheckConfig = fmt.Sprintf(`
+resource "powerscale_adsprovider" "ads_test" {
+	name = "%s"
+	user = "administrator"
+	password = "Password123!"
+	reset_schannel = true
+}
+`, adsName)
+
 var AdsProviderUpdatedResourceConfig = fmt.Sprintf(`
 resource "powerscale_adsprovider" "ads_test" {
 	name = "%s"
@@ -260,5 +277,14 @@ resource "powerscale_adsprovider" "ads_test" {
 	user = "administrator"
 	password = "Password123!"
 	check_online_interval = 290
+}
+`, adsName)
+
+var AdsProviderUpdatePreCheckConfig = fmt.Sprintf(`
+resource "powerscale_adsprovider" "ads_test" {
+	name = "%s"
+	user = "administrator"
+	password = "Password123!"
+	kerberos_hdfs_spn = true
 }
 `, adsName)


### PR DESCRIPTION
# Description
Add prechecks for create and update params to deal with the situation where fields are only allowed while creating not updating and vice versa
Use plan to update local record instead of state

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
Active Directory

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Unit tests
- [x] Acceptance tests