### PR TITLE
Fix Error Message of HTML format

### DIFF
--- a/powerscale/constants/constants.go
+++ b/powerscale/constants/constants.go
@@ -101,4 +101,7 @@ const (
 
 	// ReadWellKnownErrorMsg specifies error details occurred while reading Well-Knowns.
 	ReadWellKnownErrorMsg = "Could not read well-knowns "
+
+	// ReadClusterErrorMsg specifies error details occurred while reading cluster.
+	ReadClusterErrorMsg = "Could not read cluster "
 )

--- a/powerscale/provider/cluster_data_source.go
+++ b/powerscale/provider/cluster_data_source.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"terraform-provider-powerscale/client"
+	"terraform-provider-powerscale/powerscale/constants"
 	"terraform-provider-powerscale/powerscale/helper"
 	"terraform-provider-powerscale/powerscale/models"
 )
@@ -103,7 +104,9 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	// Read and map cluster config data
 	config, err := helper.GetClusterConfig(ctx, d.client)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cluster config, got error: %s", err))
+		errStr := constants.ReadClusterErrorMsg + "with error: "
+		message := helper.GetErrorString(err, errStr)
+		resp.Diagnostics.AddError("Error reading cluster config", message)
 		return
 	}
 	var dataConfig models.ClusterConfig
@@ -117,7 +120,9 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	// Read and map cluster identity data
 	identity, err := helper.GetClusterIdentity(ctx, d.client)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cluster identity, got error: %s", err))
+		errStr := constants.ReadClusterErrorMsg + "with error: "
+		message := helper.GetErrorString(err, errStr)
+		resp.Diagnostics.AddError("Error reading cluster config", message)
 		return
 	}
 	var dataIdentity models.ClusterIdentity
@@ -130,7 +135,9 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	nodes, err := helper.GetClusterNodes(ctx, d.client)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cluster nodes, got error: %s", err))
+		errStr := constants.ReadClusterErrorMsg + "with error: "
+		message := helper.GetErrorString(err, errStr)
+		resp.Diagnostics.AddError("Error reading cluster nodes", message)
 		return
 	}
 	var dataNodes models.ClusterNodes
@@ -143,7 +150,10 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	networks, err := helper.GetClusterInternalNetworks(ctx, d.client)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cluster internal networks, got error: %s", err))
+		errStr := constants.ReadClusterErrorMsg + "with error: "
+		message := helper.GetErrorString(err, errStr)
+		resp.Diagnostics.AddError("Error reading cluster networks", message)
+		return
 	}
 	var dataNetworks models.ClusterInternalNetworks
 	err = helper.CopyFields(ctx, networks, &dataNetworks)
@@ -155,7 +165,10 @@ func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	acs, err := helper.ListClusterAcs(ctx, d.client)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cluster acs, got error: %s", err))
+		errStr := constants.ReadClusterErrorMsg + "with error: "
+		message := helper.GetErrorString(err, errStr)
+		resp.Diagnostics.AddError("Error reading cluster acs", message)
+		return
 	}
 	var dataAcs models.ClusterAcs
 	err = helper.CopyFields(ctx, acs, &dataAcs)

--- a/powerscale/provider/cluster_data_source_test.go
+++ b/powerscale/provider/cluster_data_source_test.go
@@ -72,7 +72,7 @@ func TestAccClusterConfigError(t *testing.T) {
 					FunctionMocker = Mock(helper.GetClusterConfig).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfig + testAccClusterDataSourceConfig,
-				ExpectError: regexp.MustCompile(`.*Client Error*.`),
+				ExpectError: regexp.MustCompile(`.*Error reading cluster*.`),
 			},
 		},
 		CheckDestroy: func(_ *terraform.State) error {
@@ -95,7 +95,7 @@ func TestAccClusterIdentityError(t *testing.T) {
 					FunctionMocker = Mock(helper.GetClusterIdentity).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfig + testAccClusterDataSourceConfig,
-				ExpectError: regexp.MustCompile(`.*Client Error*.`),
+				ExpectError: regexp.MustCompile(`.*Error reading cluster*.`),
 			},
 		},
 		CheckDestroy: func(_ *terraform.State) error {
@@ -118,7 +118,7 @@ func TestAccClusterNodesError(t *testing.T) {
 					FunctionMocker = Mock(helper.GetClusterNodes).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfig + testAccClusterDataSourceConfig,
-				ExpectError: regexp.MustCompile(`.*Client Error*.`),
+				ExpectError: regexp.MustCompile(`.*Error reading cluster*.`),
 			},
 		},
 		CheckDestroy: func(_ *terraform.State) error {
@@ -141,7 +141,7 @@ func TestAccClusterInternalNetworksError(t *testing.T) {
 					FunctionMocker = Mock(helper.GetClusterInternalNetworks).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfig + testAccClusterDataSourceConfig,
-				ExpectError: regexp.MustCompile(`.*Client Error*.`),
+				ExpectError: regexp.MustCompile(`.*Error reading cluster*.`),
 			},
 		},
 		CheckDestroy: func(_ *terraform.State) error {
@@ -164,7 +164,7 @@ func TestAccClusterAcsError(t *testing.T) {
 					FunctionMocker = Mock(helper.ListClusterAcs).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfig + testAccClusterDataSourceConfig,
-				ExpectError: regexp.MustCompile(`.*Client Error*.`),
+				ExpectError: regexp.MustCompile(`.*Error reading cluster*.`),
 			},
 		},
 		CheckDestroy: func(_ *terraform.State) error {


### PR DESCRIPTION
# Description
Fix Error Message of HTML format

##### OUTPUT
```paste below
│ Error: Error reading cluster config
│
│   with data.powerscale_cluster.test,
│   on data-source.tf line 17, in data "powerscale_cluster" "test":
│   17: data "powerscale_cluster" "test" {
│
│ Could not read cluster with error: 401 Unauthorized to access PAPI. undefined response type

```

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests