### PR TITLE
File system validate owner/group information

### DIFF
--- a/powerscale/provider/file_system_resource_test.go
+++ b/powerscale/provider/file_system_resource_test.go
@@ -104,10 +104,10 @@ func TestFileSystemResourceUpdateUserErr(t *testing.T) {
 			//Update owner/group/accessControl, then Read testing
 			{
 				PreConfig: func() {
-					FunctionMocker = Mock(helper.UpdateFileSystem).Return(fmt.Errorf("Error Updating User / Groups for the filesystem")).Build()
+					FunctionMocker = Mock(helper.UpdateFileSystem).Return(fmt.Errorf("Error updating user")).Build()
 				},
 				Config:      ProviderConfig + FileSystemUpdateResourceConfig,
-				ExpectError: regexp.MustCompile(`.*Error Updating User / Groups for the filesystem*.`),
+				ExpectError: regexp.MustCompile(`.*Error updating user*.`),
 			},
 		},
 	})
@@ -124,10 +124,10 @@ func TestFileSystemResourceUpdateACLErr(t *testing.T) {
 			//Update owner/group/accessControl, then Read testing
 			{
 				PreConfig: func() {
-					FunctionMocker = Mock(helper.UpdateFileSystem).Return(fmt.Errorf("Error Updating AccesControl for the filesystem")).Build()
+					FunctionMocker = Mock(helper.UpdateFileSystem).Return(fmt.Errorf("Error updating acl")).Build()
 				},
 				Config:      ProviderConfig + FileSystemUpdateResourceConfig,
-				ExpectError: regexp.MustCompile(`.*Error Updating AccesControl for the filesystem*.`),
+				ExpectError: regexp.MustCompile(`.*Error updating acl*.`),
 			},
 		},
 	})


### PR DESCRIPTION
# Description
Validate owner/group information for File System Resource
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
File System Resource

##### OUTPUT
![FS_resource](https://github.com/dell/terraform-provider-powerscale/assets/131491094/47a64cc3-25dc-4853-8be9-8b81b52fcf84)


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests