### PR TITLE
Fix AccessZone User FileSystem Error

### DIFF
--- a/docs/resources/filesystem.md
+++ b/docs/resources/filesystem.md
@@ -68,6 +68,10 @@ resource "powerscale_filesystem" "file_system_test" {
     type = "user"
   }
 
+  # Optional : query_zone, this will default to the default access zone if unset. However is needed if the user trying to be created is not in the default access zone.connection {
+  # This should just be the access zone name. 
+  # query_zone = "test_access_zone"
+
   # Optional attributes. Default values set.
   # Creates intermediate folders recursively, when set to true.
   recursive = true
@@ -103,6 +107,7 @@ After the execution of above resource block, a powerscale_filesystem would have 
 - `directory_path` (String) FileSystem directory path.This specifies the path to the FileSystem(Namespace directory) which we are trying to manage. If no directory path is specified, [/ifs] would be taken by default.
 - `id` (String) FileSystem identifier. Unique identifier for the FileSystem(Namespace directory)
 - `overwrite` (Boolean) Deletes and replaces the existing user attributes and ACLs of the directory with user-specified attributes if set to true.
+- `query_zone` (String) Specifies the zone that the object belongs to. Optional and will default to the default access zone if one is not set.
 - `recursive` (Boolean) Creates intermediate folders recursively when set to true.
 
 ### Read-Only

--- a/examples/resources/powerscale_filesystem/resource.tf
+++ b/examples/resources/powerscale_filesystem/resource.tf
@@ -36,6 +36,10 @@ resource "powerscale_filesystem" "file_system_test" {
     type = "user"
   }
 
+  # Optional : query_zone, this will default to the default access zone if unset. However is needed if the user trying to be created is not in the default access zone.connection {
+  # This should just be the access zone name. 
+  # query_zone = "test_access_zone"
+
   # Optional attributes. Default values set.
   # Creates intermediate folders recursively, when set to true.
   recursive = true

--- a/powerscale/models/file_system.go
+++ b/powerscale/models/file_system.go
@@ -170,6 +170,8 @@ type FileSystemResource struct {
 	Group         MemberObject `tfsdk:"group"`
 	Type          types.String `tfsdk:"type"`
 	CreationTime  types.String `tfsdk:"creation_time"`
+	// If the user wants to filter on a partcular access zone they can set that here, otherwise will just default to the default access zone.
+	QueryZone types.String `tfsdk:"query_zone"`
 	// The ACL value for the directory. Users can either provide access rights input such as 'private_read' , 'private' ,
 	//'public_read', 'public_read_write', 'public' or permissions in POSIX format as '0550', '0770', '0775','0777' or 0700. The Default value is (0700).Modification of ACL is only supported from POSIX to POSIX mode.",
 	AccessControl types.String `tfsdk:"access_control"`


### PR DESCRIPTION
# Description
- When creating a File System if the user that is being added is from a different access zone allow the user to input the query_zone paramenter to set that particular access zone. Otherwise it will default to the default access zone when creating.

# GitHub Issues

# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
Filesystem Resource

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests