### PR TITLE
Fix groupnet rename issue of ads provider

### DIFF
--- a/powerscale/helper/ads_provider_helper.go
+++ b/powerscale/helper/ads_provider_helper.go
@@ -78,7 +78,6 @@ func IsCreateAdsProviderParamInvalid(plan models.AdsProviderResourceModel) bool 
 // IsUpdateAdsProviderParamInvalid Verify if update params contain params only for creating.
 func IsUpdateAdsProviderParamInvalid(plan models.AdsProviderResourceModel, state models.AdsProviderResourceModel) bool {
 	if (!plan.DNSDomain.IsNull() && !state.DNSDomain.Equal(plan.DNSDomain)) ||
-		(!plan.Groupnet.IsUnknown() && !state.Groupnet.Equal(plan.Groupnet)) ||
 		(!plan.Instance.IsNull() && !state.Instance.Equal(plan.Instance)) ||
 		(!plan.KerberosHdfsSpn.IsNull() && !state.KerberosHdfsSpn.Equal(plan.KerberosHdfsSpn)) ||
 		(!plan.KerberosNfsSpn.IsNull() && !state.KerberosNfsSpn.Equal(plan.KerberosNfsSpn)) ||
@@ -87,4 +86,12 @@ func IsUpdateAdsProviderParamInvalid(plan models.AdsProviderResourceModel, state
 		return true
 	}
 	return false
+}
+
+// IsGroupnetUpdated Verify if groupnet is updated after creation.
+func IsGroupnetUpdated(groupnetInPlan string, groupnetInResp string) bool {
+	if groupnetInPlan == "" {
+		return false
+	}
+	return groupnetInResp != groupnetInPlan
 }

--- a/powerscale/provider/ads_provider_resource.go
+++ b/powerscale/provider/ads_provider_resource.go
@@ -653,6 +653,14 @@ func (r *AdsProviderResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	if helper.IsGroupnetUpdated(adsPlan.Groupnet.ValueString(), *updatedAds.Ads[0].Groupnet) {
+		resp.Diagnostics.AddError(
+			"Error updating ads provider",
+			"Should not use a different groupnet",
+		)
+		return
+	}
+
 	err = helper.CopyFieldsToNonNestedModel(ctx, updatedAds.Ads[0], &adsPlan)
 	if err != nil {
 		errStr := constants.ReadAdsProviderErrorMsg + "with error: "

--- a/powerscale/provider/ads_provider_resource_test.go
+++ b/powerscale/provider/ads_provider_resource_test.go
@@ -158,6 +158,10 @@ func TestAccAdsProviderResourceErrorUpdate(t *testing.T) {
 				Config:      ProviderConfig + AdsProviderUpdatePreCheckConfig,
 				ExpectError: regexp.MustCompile(".*Should not provide parameters for creating*."),
 			},
+			{
+				Config:      ProviderConfig + AdsProviderUpdateGroupnetConfig,
+				ExpectError: regexp.MustCompile(".*Should not use a different groupnet*."),
+			},
 		},
 	})
 }
@@ -286,5 +290,14 @@ resource "powerscale_adsprovider" "ads_test" {
 	user = "administrator"
 	password = "Password123!"
 	kerberos_hdfs_spn = true
+}
+`, adsName)
+
+var AdsProviderUpdateGroupnetConfig = fmt.Sprintf(`
+resource "powerscale_adsprovider" "ads_test" {
+	name = "%s"
+	user = "administrator"
+	password = "Password123!"
+	groupnet = "groupnet_x"
 }
 `, adsName)


### PR DESCRIPTION
# Description
Since we have new resource groupnet, need to support groupnet rename on ads provider.

# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE NAME
ads provider

##### OUTPUT
Test all passed: https://osj-sio-03-prd.cec.lab.emc.com/view/Terraform/job/Terraform-Pipelines/job/tf-manual/865/Summary_20Report/

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests