### PR TITLE
Improve coverage for user_group_helper and network_settings_helper

### DIFF
--- a/powerscale/provider/network_setting_resource_test.go
+++ b/powerscale/provider/network_setting_resource_test.go
@@ -224,6 +224,43 @@ func TestAccNetworkSettingResourceUpdateMockErr(t *testing.T) {
 	})
 }
 
+func TestAccNetworkSettingResourceHelperMockErr(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read Error testing
+			{
+				PreConfig: func() {
+					if networkSettingGetMocker != nil {
+						networkSettingGetMocker.UnPatch()
+					}
+					if networkSettingMocker != nil {
+						networkSettingMocker.UnPatch()
+					}
+					networkSettingGetMocker = Mock((*powerscale.NetworkApiService).GetNetworkv12NetworkExternalExecute).Return(nil, nil, fmt.Errorf("networkSettings read mock error")).Build()
+				},
+				Config:      ProviderConfig + networkSettingBasicResourceConfig,
+				ExpectError: regexp.MustCompile(`.*networkSettings read mock error*.`),
+			},
+			// Create and Read Error testing
+			{
+				PreConfig: func() {
+					if networkSettingGetMocker != nil {
+						networkSettingGetMocker.UnPatch()
+					}
+					if networkSettingMocker != nil {
+						networkSettingMocker.UnPatch()
+					}
+					networkSettingMocker = Mock((*powerscale.NetworkApiService).UpdateNetworkv12NetworkExternalExecute).Return(nil, fmt.Errorf("networkSettings update mock error")).Build()
+				},
+				Config:      ProviderConfig + networkSettingBasicResourceConfig,
+				ExpectError: regexp.MustCompile(`.*networkSettings update mock error*.`),
+			},
+		},
+	})
+}
+
 func TestAccNetworkSettingReleaseMockResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },


### PR DESCRIPTION
# Description
Improve coverage for user_group_helper and network_settings_helper.
All AT and UT tests are passed.

![image](https://github.com/dell/terraform-provider-powerscale/assets/88763781/26e8d674-ff99-4ca8-8c9c-9484858d0a71)


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests