### PR TITLE
Doc update: move best practices to a separate section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,15 +49,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-# Best Practices
-# 1. The parent resource attributes of a certain resource (e.g. groupnet field of subnet resource) can only be designated
-#    at creation. Once designated, they cannot be modified except for parent resource renaming.
-# 2. The name of a resource is modifiable, but it is necessary to make sure its name referenced in the child resources
-#    is also updated (can be done manually or use reference resource_id.name).
-# 3. Resources with child resources cannot be deleted independently. Use terraform destroy to delete all resources directly
-#    or delete all the child resources at the same time (depends_on is recommended to manage resources, serving as a
-#    precheck for delete operations).
-
 terraform {
   required_providers {
     powerscale = {
@@ -198,3 +189,12 @@ resource "powerscale_smb_share" "share_example" {
 
 - `auth_type` (Number) what should be the auth type, 0 for basic and 1 for session-based
 - `timeout` (Number) specifies a time limit for requests
+
+## Best Practices
+1. The parent resource attributes of a certain resource (e.g. groupnet field of subnet resource) can only be designated
+   at creation. Once designated, they cannot be modified except for parent resource renaming.
+2. The name of a resource is modifiable, but it is necessary to make sure its name referenced in the child resources
+   is also updated (can be done manually or use reference resource_id.name).
+3. Resources with child resources cannot be deleted independently. Use terraform destroy to delete all resources directly
+   or delete all the child resources at the same time (depends_on is recommended to manage resources, serving as a
+   precheck for delete operations).

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -15,15 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-# Best Practices
-# 1. The parent resource attributes of a certain resource (e.g. groupnet field of subnet resource) can only be designated
-#    at creation. Once designated, they cannot be modified except for parent resource renaming.
-# 2. The name of a resource is modifiable, but it is necessary to make sure its name referenced in the child resources
-#    is also updated (can be done manually or use reference resource_id.name).
-# 3. Resources with child resources cannot be deleted independently. Use terraform destroy to delete all resources directly
-#    or delete all the child resources at the same time (depends_on is recommended to manage resources, serving as a
-#    precheck for delete operations).
-
 terraform {
   required_providers {
     powerscale = {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -36,3 +36,12 @@ The following abridged example demonstrates the usage of the provider to create 
 {{- end }}
 
 {{ .SchemaMarkdown | trimspace }}
+
+## Best Practices
+1. The parent resource attributes of a certain resource (e.g. groupnet field of subnet resource) can only be designated
+   at creation. Once designated, they cannot be modified except for parent resource renaming.
+2. The name of a resource is modifiable, but it is necessary to make sure its name referenced in the child resources
+   is also updated (can be done manually or use reference resource_id.name).
+3. Resources with child resources cannot be deleted independently. Use terraform destroy to delete all resources directly
+   or delete all the child resources at the same time (depends_on is recommended to manage resources, serving as a
+   precheck for delete operations).


### PR DESCRIPTION
# Description
Doc update: move best practices to a separate section to make it more visible for the customers
![image](https://github.com/dell/terraform-provider-powerscale/assets/136694818/5fa943fd-984b-4e8e-90f7-9e08833e0908)

# ISSUE TYPE
- Docs Pull Request

# OUTPUT
http://10.225.108.43:1313/terraform-docs/v1.1.0/storage/platforms/powerscale/product_guide/provider/

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests