### PR TITLE
Tune connection performance

### DIFF
--- a/powerscale/helper/access_zone_helper.go
+++ b/powerscale/helper/access_zone_helper.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	powerscale "dell/powerscale-go-client"
 	"fmt"
-	"strconv"
 	"strings"
 	"terraform-provider-powerscale/client"
 	"terraform-provider-powerscale/powerscale/constants"
@@ -162,20 +161,4 @@ func QueryZoneNameByID(ctx context.Context, client *client.Client, zoneID int32)
 	}
 
 	return "", fmt.Errorf("error finding zone name for zone ID %d", zoneID)
-}
-
-// QueryZoneIDByName returns a specific zone id by name.
-func QueryZoneIDByName(ctx context.Context, client *client.Client, zoneName string) (string, error) {
-	zones, err := GetAllAccessZones(ctx, client)
-	if err != nil {
-		return "", err
-	}
-	for _, zone := range zones.Zones {
-		if *zone.Name == zoneName {
-
-			return strconv.Itoa(int(*zone.ZoneId)), nil
-		}
-	}
-
-	return "", fmt.Errorf("error finding zone ID for zone name %s", zoneName)
 }

--- a/powerscale/helper/file_system_helper.go
+++ b/powerscale/helper/file_system_helper.go
@@ -334,7 +334,7 @@ const acl = "acl"
 const mode = "mode"
 
 // UpdateFileSystem Updates the file system attributes.
-func UpdateFileSystem(ctx context.Context, client client.Client, dirPath string, plan *models.FileSystemResource, state *models.FileSystemResource) error {
+func UpdateFileSystem(ctx context.Context, client *client.Client, dirPath string, plan *models.FileSystemResource, state *models.FileSystemResource) error {
 
 	// Update Owner / Group if modified
 	if plan.Owner.Name.ValueString() != state.Owner.Name.ValueString() || plan.Group.Name.ValueString() != state.Group.Name.ValueString() ||
@@ -416,7 +416,7 @@ func getNewAccessControlParams(accessControl string) (string, string) {
 }
 
 // ValidateUserAndGroup check if owner/group information is correct.
-func ValidateUserAndGroup(ctx context.Context, client client.Client, owner models.MemberObject, group models.MemberObject, accessZone string) error {
+func ValidateUserAndGroup(ctx context.Context, client *client.Client, owner models.MemberObject, group models.MemberObject, accessZone string) error {
 	// Validate owner information
 	userReq := client.PscaleOpenAPIClient.AuthApi.GetAuthv1AuthUser(ctx, owner.Name.ValueString())
 

--- a/powerscale/helper/smart_pool_settting_helper.go
+++ b/powerscale/helper/smart_pool_settting_helper.go
@@ -49,7 +49,12 @@ type SettingsSetter interface {
 
 // GetSmartPoolSettings Get SmartPool settings based on Onefs version.
 func GetSmartPoolSettings(ctx context.Context, powerscaleClient *client.Client) (any, error) {
-	if powerscaleClient.OnefsVersion.IsGreaterThan("9.4.0") {
+	onfsVersion, err := powerscaleClient.GetOnefsVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OneFS version: %v", err)
+	}
+
+	if onfsVersion.IsGreaterThan("9.4.0") {
 		settings, _, err := powerscaleClient.PscaleOpenAPIClient.StoragepoolApi.GetStoragepoolv16StoragepoolSettings(ctx).Execute()
 		return settings, err
 	}
@@ -255,7 +260,12 @@ func BigFloatToInt32(x *big.Float) (*int32, error) {
 
 // UpdateSmartPoolSettings apply SmartPool Settings changes on PowerScale.
 func UpdateSmartPoolSettings(ctx context.Context, client *client.Client, model *models.SmartPoolSettingsResource) error {
-	if client.OnefsVersion.IsGreaterThan("9.4.0") {
+	onfsVersion, err := client.GetOnefsVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get OneFS version: %v", err)
+	}
+
+	if onfsVersion.IsGreaterThan("9.4.0") {
 		updateParam := client.PscaleOpenAPIClient.StoragepoolApi.UpdateStoragepoolv16StoragepoolSettings(ctx)
 		settings := powerscale.V16StoragepoolSettingsExtended{}
 
@@ -289,7 +299,7 @@ func UpdateSmartPoolSettings(ctx context.Context, client *client.Client, model *
 	updateParam := client.PscaleOpenAPIClient.StoragepoolApi.UpdateStoragepoolv5StoragepoolSettings(ctx)
 	settings := powerscale.V5StoragepoolSettingsExtended{}
 
-	err := ReadFromState(ctx, model, &settings)
+	err = ReadFromState(ctx, model, &settings)
 	if err != nil {
 		return err
 	}

--- a/powerscale/provider/access_zone_resource_test.go
+++ b/powerscale/provider/access_zone_resource_test.go
@@ -19,6 +19,7 @@ package provider
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"regexp"
 	"terraform-provider-powerscale/powerscale/helper"
 	"testing"
@@ -107,11 +108,20 @@ func TestAccAccessZoneResourceAfterCreateGetErr(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
+					if mocker != nil {
+						mocker.UnPatch()
+					}
 					mocker = mockey.Mock(helper.GetAllAccessZones).Return(nil, fmt.Errorf("access zone read mock error")).Build()
 				},
 				Config:      ProviderConfig + AccessZoneResourceConfig,
 				ExpectError: regexp.MustCompile(`.*access zone read mock error*.`),
 			},
+		},
+		CheckDestroy: func(_ *terraform.State) error {
+			if mocker != nil {
+				mocker.UnPatch()
+			}
+			return nil
 		},
 	})
 }
@@ -127,12 +137,24 @@ func TestAccAccessZoneResourceGetErr(t *testing.T) {
 					if mocker != nil {
 						mocker.UnPatch()
 					}
+					if createMocker != nil {
+						createMocker.UnPatch()
+					}
 					createMocker = mockey.Mock(helper.CreateAccessZones).Return(nil).Build()
 					mocker = mockey.Mock(helper.GetAllAccessZones).Return(nil, fmt.Errorf("access zone read mock error")).Build()
 				},
 				Config:      ProviderConfig + AccessZoneResourceConfig,
 				ExpectError: regexp.MustCompile(`.*access zone read mock error*.`),
 			},
+		},
+		CheckDestroy: func(_ *terraform.State) error {
+			if mocker != nil {
+				mocker.UnPatch()
+			}
+			if createMocker != nil {
+				createMocker.UnPatch()
+			}
+			return nil
 		},
 	})
 }
@@ -163,6 +185,9 @@ func TestAccAccessZoneResourceGetImportErr(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
+					if mocker != nil {
+						mocker.UnPatch()
+					}
 					mocker = mockey.Mock(helper.GetAllAccessZones).Return(nil, fmt.Errorf("access zone read mock error")).Build()
 				},
 				ResourceName:      accessZoneResourceName,
@@ -170,6 +195,15 @@ func TestAccAccessZoneResourceGetImportErr(t *testing.T) {
 				ImportStateVerify: true,
 				ExpectError:       regexp.MustCompile(`.*access zone read mock error*.`),
 			},
+		},
+		CheckDestroy: func(_ *terraform.State) error {
+			if createMocker != nil {
+				createMocker.UnPatch()
+			}
+			if mocker != nil {
+				mocker.UnPatch()
+			}
+			return nil
 		},
 	})
 }

--- a/powerscale/provider/file_system_resource.go
+++ b/powerscale/provider/file_system_resource.go
@@ -239,7 +239,7 @@ func (r *FileSystemResource) Create(ctx context.Context, req resource.CreateRequ
 	if !plan.AccessControl.IsNull() && (plan.AccessControl.ValueString() != "") {
 		createReq = createReq.XIsiIfsAccessControl(plan.AccessControl.ValueString())
 	}
-	errAuth := helper.ValidateUserAndGroup(ctx, *r.client, plan.Owner, plan.Group, plan.QueryZone.ValueString())
+	errAuth := helper.ValidateUserAndGroup(ctx, r.client, plan.Owner, plan.Group, plan.QueryZone.ValueString())
 	if errAuth != nil {
 		errStr := constants.CreateFileSystemErrorMsg
 		message := helper.GetErrorString(errAuth, errStr)
@@ -384,7 +384,7 @@ func (r *FileSystemResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	//copy to model
+	// copy to model
 	var state models.FileSystemResource
 	helper.UpdateFileSystemResourceState(ctx, &plan, &state, acl, meta)
 	helper.UpdateFileSystemResourcePlanData(&plan, &state)
@@ -442,7 +442,7 @@ func (r *FileSystemResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	if err := helper.UpdateFileSystem(ctx, *r.client, planDirName, &plan, &state); err != nil {
+	if err := helper.UpdateFileSystem(ctx, r.client, planDirName, &plan, &state); err != nil {
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error updating the File system Resource - %s", planDirName),
 			err.Error(),
@@ -474,7 +474,7 @@ func (r *FileSystemResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	//copy to model
+	// copy to model
 	helper.UpdateFileSystemResourceState(ctx, &plan, &state, acl, meta)
 	helper.UpdateFileSystemResourcePlanData(&plan, &state)
 
@@ -512,7 +512,7 @@ func (r *FileSystemResource) ImportState(ctx context.Context, req resource.Impor
 		return
 	}
 
-	//copy to model
+	// copy to model
 	helper.UpdateFileSystemResourceState(ctx, nil, &state, acl, meta)
 	state.ID = types.StringValue(id)
 	dir, name := filepath.Split(id)

--- a/powerscale/provider/provider.go
+++ b/powerscale/provider/provider.go
@@ -42,7 +42,7 @@ type PscaleProvider struct {
 	// client can contain the upstream provider SDK or HTTP client used to
 	// communicate with the upstream service. Resource and DataSource
 	// implementations can then make calls using this client.
-	client *client.Client
+
 	// version is set to the provider version on release, "dev" when the
 	// provider is built and ran locally, and "test" when running acceptance
 	// testing.
@@ -153,7 +153,6 @@ func (p *PscaleProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	}
 
 	// client configuration for data sources and resources
-	p.client = pscaleClient
 	resp.DataSourceData = pscaleClient
 	resp.ResourceData = pscaleClient
 }

--- a/powerscale/provider/smart_pool_setting_datasource_test.go
+++ b/powerscale/provider/smart_pool_setting_datasource_test.go
@@ -184,14 +184,16 @@ func TestAccSmartPoolSettingsDatasourceV16(t *testing.T) {
 				PreConfig: func() {
 					FunctionMocker = Mock(helper.GetSmartPoolSettings).Build().
 						When(func(ctx context.Context, powerscaleClient *client.Client) bool {
+							onefsVersion, _ := powerscaleClient.GetOnefsVersion()
+
 							if strings.Contains(powerscaleClient.PscaleOpenAPIClient.GetConfig().Servers[0].URL, "localhost") {
 								// enforce 9.5 (i.e. v16) endpoint in mock server
-								powerscaleClient.OnefsVersion = client.OnefsVersion{Major: 9, Minor: 5, Patch: 0}
+								powerscaleClient.SetOnefsVersion(9, 5, 0)
 								return false
 							} else if !strings.Contains(powerscaleClient.PscaleOpenAPIClient.GetConfig().Servers[0].URL, "localhost") &&
-								powerscaleClient.OnefsVersion.IsLessThan("9.5.0") {
+								onefsVersion.IsLessThan("9.5.0") {
 								// if running against an actual PowerScale 9.4, v16 is invalid, use mock data
-								powerscaleClient.OnefsVersion = client.OnefsVersion{Major: 9, Minor: 5, Patch: 0}
+								powerscaleClient.SetOnefsVersion(9, 5, 0)
 								return true
 							}
 							return false

--- a/powerscale/provider/smart_pool_setting_resource_test.go
+++ b/powerscale/provider/smart_pool_setting_resource_test.go
@@ -82,13 +82,14 @@ func TestAccSmartPoolSettingsResourceUpdate(t *testing.T) {
 					restV5UpdateFuncMocker = Mock(powerscale.ApiUpdateStoragepoolv5StoragepoolSettingsRequest.Execute).Return(nil, nil).Build()
 					restV16UpdateFuncMocker = Mock(powerscale.ApiUpdateStoragepoolv16StoragepoolSettingsRequest.Execute).Return(nil, nil).Build()
 					FunctionMocker = Mock(helper.GetSmartPoolSettings).To(func(ctx context.Context, powerscaleClient *client.Client) (any, error) {
+						onefsVersion, _ := powerscaleClient.GetOnefsVersion()
 						if restV5UpdateFuncMocker.MockTimes() > 0 {
 							return mockV5StoragepoolSettingsAfterUpdate, nil
 						}
 						if restV16UpdateFuncMocker.MockTimes() > 0 {
 							return mockV16StoragepoolSettingsAfterUpdate, nil
 						}
-						if powerscaleClient.OnefsVersion.IsGreaterThan("9.4.0") {
+						if onefsVersion.IsGreaterThan("9.4.0") {
 							return mockV16StoragepoolSettingsBeforeUpdate, nil
 						}
 						return mockV5StoragepoolSettingsBeforeUpdate, nil
@@ -183,7 +184,8 @@ func TestAccSmartPoolSettingsResourceUpdateErrorRequest(t *testing.T) {
 							if updateFuncMocker.MockTimes() > 0 {
 								return nil, fmt.Errorf("mock error")
 							}
-							if powerscaleClient.OnefsVersion.IsGreaterThan("9.4.0") {
+							onefsVersion, _ := powerscaleClient.GetOnefsVersion()
+							if onefsVersion.IsGreaterThan("9.4.0") {
 								return mockV16StoragepoolSettingsBeforeUpdate, nil
 							}
 							return mockV5StoragepoolSettingsBeforeUpdate, nil
@@ -221,12 +223,13 @@ func TestAccSmartPoolSettingsResourceV16(t *testing.T) {
 					restV16UpdateFuncMocker = Mock(powerscale.ApiUpdateStoragepoolv16StoragepoolSettingsRequest.Execute).Return(nil, nil).Build()
 					FunctionMocker = Mock(helper.GetSmartPoolSettings).Build().
 						When(func(ctx context.Context, powerscaleClient *client.Client) bool {
+							onefsVersion, _ := powerscaleClient.GetOnefsVersion()
 							if strings.Contains(powerscaleClient.PscaleOpenAPIClient.GetConfig().Servers[0].URL, "localhost") {
-								powerscaleClient.OnefsVersion = client.OnefsVersion{Major: 9, Minor: 5, Patch: 0}
+								powerscaleClient.SetOnefsVersion(9, 5, 0)
 								return false
 							}
 							if !strings.Contains(powerscaleClient.PscaleOpenAPIClient.GetConfig().Servers[0].URL, "localhost") &&
-								powerscaleClient.OnefsVersion.IsGreaterThan("9.4.0") {
+								onefsVersion.IsGreaterThan("9.4.0") {
 								return false
 							}
 							return true


### PR DESCRIPTION
Tune connection performance

- Add configuration to http.Transport

- Move OneFS version creation to method `client.GetOnefsVersion()` that can be invoked as needed, also it will not delay client initialization.

- The following bug is fixed in the PR:
  Fix PowerScale token cannot be refreshed after expiration.

# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### RESOURCE OR DATASOURCE NAME
<!--- Write the short name of the resource or datasource below -->

##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests