### PR TITLE
Add Zone as Parameter to CRUD operations

### DIFF
--- a/docs/resources/nfs_export_settings.md
+++ b/docs/resources/nfs_export_settings.md
@@ -72,6 +72,9 @@ resource "powerscale_nfs_export_settings" "example" {
   #      id = "USER:nobody"
   #    }
   #  }
+  #
+  # Specifies the zone in which the export is valid. Notice that update this field will change the resource you manage.
+  #  zone = "System"
 }
 
 # After the execution of above resource block, NFS export settings would have been cached in terraform state file, or

--- a/examples/resources/powerscale_nfs_export_settings/resource.tf
+++ b/examples/resources/powerscale_nfs_export_settings/resource.tf
@@ -39,6 +39,9 @@ resource "powerscale_nfs_export_settings" "example" {
   #      id = "USER:nobody"
   #    }
   #  }
+  #
+  # Specifies the zone in which the export is valid. Notice that update this field will change the resource you manage.
+  #  zone = "System"
 }
 
 # After the execution of above resource block, NFS export settings would have been cached in terraform state file, or

--- a/powerscale/helper/nfs_export_settings.go
+++ b/powerscale/helper/nfs_export_settings.go
@@ -24,12 +24,6 @@ import (
 	"terraform-provider-powerscale/powerscale/models"
 )
 
-// GetNfsExportSettings retrieve nfs export settings.
-func GetNfsExportSettings(ctx context.Context, client *client.Client) (*powerscale.V2NfsSettingsExport, error) {
-	nfsExportSettings, _, err := client.PscaleOpenAPIClient.ProtocolsApi.GetProtocolsv2NfsSettingsExport(ctx).Execute()
-	return nfsExportSettings, err
-}
-
 // GetNfsExportSettingsByZone retrieve nfs export settings by zone.
 func GetNfsExportSettingsByZone(ctx context.Context, client *client.Client, zone string) (*powerscale.V2NfsSettingsExport, error) {
 	nfsExportSettings, _, err := client.PscaleOpenAPIClient.ProtocolsApi.GetProtocolsv2NfsSettingsExport(ctx).Zone(zone).Execute()
@@ -37,8 +31,8 @@ func GetNfsExportSettingsByZone(ctx context.Context, client *client.Client, zone
 }
 
 // UpdateNfsExportSettings update nfs export settings.
-func UpdateNfsExportSettings(ctx context.Context, client *client.Client, nfsExportSettings powerscale.V2NfsSettingsExportSettings) error {
-	_, err := client.PscaleOpenAPIClient.ProtocolsApi.UpdateProtocolsv2NfsSettingsExport(ctx).V2NfsSettingsExport(nfsExportSettings).Execute()
+func UpdateNfsExportSettings(ctx context.Context, client *client.Client, nfsExportSettings powerscale.V2NfsSettingsExportSettings, zone string) error {
+	_, err := client.PscaleOpenAPIClient.ProtocolsApi.UpdateProtocolsv2NfsSettingsExport(ctx).V2NfsSettingsExport(nfsExportSettings).Zone(zone).Execute()
 	return err
 }
 
@@ -67,4 +61,12 @@ func SetDefaultValues(nfsExportSettingsModel *models.NfsexportsettingsModel, nfs
 		nfsExportSettings.Snapshot = &value
 	}
 	return nil
+}
+
+// GetSpecifiedZone retrieve zone from plan, or state if it is not defined in plan
+func GetSpecifiedZone(plan *models.NfsexportsettingsModel, state *models.NfsexportsettingsModel) string {
+	if plan.Zone.ValueString() != "" {
+		return plan.Zone.ValueString()
+	}
+	return state.Zone.ValueString()
 }

--- a/powerscale/provider/nfs_export_settings_resource_test.go
+++ b/powerscale/provider/nfs_export_settings_resource_test.go
@@ -118,7 +118,7 @@ func TestAccNfsExportSettingsCreateMockErr(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					FunctionMocker = mockey.Mock(helper.GetNfsExportSettings).Return(nil, fmt.Errorf("mock error")).Build()
+					FunctionMocker = mockey.Mock(helper.GetNfsExportSettingsByZone).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfig + nfsExportSettingsResourceConfig,
 				ExpectError: regexp.MustCompile(`.*mock error*.`),
@@ -167,7 +167,7 @@ func TestAccNfsExportSettingsUpdateMockErr(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					FunctionMocker = mockey.Mock(helper.GetNfsExportSettings).Return(nil, fmt.Errorf("mock error")).Build()
+					FunctionMocker = mockey.Mock(helper.GetNfsExportSettingsByZone).Return(nil, fmt.Errorf("mock error")).Build()
 				},
 				Config:      ProviderConfig + nfsExportSettingsUpdateResourceConfig,
 				ExpectError: regexp.MustCompile(`.*mock error*.`),


### PR DESCRIPTION
# Description
Import of Nfs Export Settings with parameter does not function as expected.
Need to add parameter to other function as well, which will be affected by import.


# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
NFS Export Settings

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests