### PR TITLE
Removing synciq service policy related attributes

### DIFF
--- a/docs/data-sources/synciq_rule.md
+++ b/docs/data-sources/synciq_rule.md
@@ -19,12 +19,12 @@ linkTitle: "powerscale_synciq_rule"
 page_title: "powerscale_synciq_rule Data Source - terraform-provider-powerscale"
 subcategory: ""
 description: |-
-  
+  This datasource is used to query the existing SyncIQ Replication Rules from PowerScale array.
 ---
 
 # powerscale_synciq_rule (Data Source)
 
-
+This datasource is used to query the existing SyncIQ Replication Rules from PowerScale array.
 
 ## Example Usage
 

--- a/docs/resources/synciq_policy.md
+++ b/docs/resources/synciq_policy.md
@@ -19,12 +19,12 @@ linkTitle: "powerscale_synciq_policy"
 page_title: "powerscale_synciq_policy Resource - terraform-provider-powerscale"
 subcategory: ""
 description: |-
-  
+  This resource is used to manage the SyncIQ Replication Policy entity of PowerScale Array. We can Create, Read, Update and Delete the SyncIQ Replication Policy using this resource. We can also import existing SyncIQ Replication Policy from PowerScale array.
 ---
 
 # powerscale_synciq_policy (Resource)
 
-
+This resource is used to manage the SyncIQ Replication Policy entity of PowerScale Array. We can Create, Read, Update and Delete the SyncIQ Replication Policy using this resource. We can also import existing SyncIQ Replication Policy from PowerScale array.
 
 
 ## Example Usage
@@ -196,7 +196,6 @@ resource "powerscale_synciq_policy" "policy_when_source_modified" {
 - `force_interface` (Boolean) NOTE: This field should not be changed without the help of PowerScale support.  Determines whether data is sent only through the subnet and pool specified in the "source_network" field. This option can be useful if there are multiple interfaces for the given source subnet.  If you enable this option, the net.inet.ip.choose_ifa_by_ipsrc sysctl should be set.
 - `ignore_recursive_quota` (Boolean) If set to true, SyncIQ will not check the recursive quota in target paths to aid in replication to target paths which contain no quota but target cluster has lots of quotas.
 - `job_delay` (Number) If `schedule` is set to `when-source-modified`, the duration to wait after a modification is made before starting a job (default is 0 seconds).
-- `linked_service_policies` (List of String) A list of service replication policies that this data replication policy will be associated with.
 - `log_level` (String) Severity an event must reach before it is logged. Accepted values are `fatal`, `error`, `notice`, `info`, `copy`, `debug`, `trace`.
 - `log_removed_files` (Boolean) If true, the system will log any files or directories that are deleted due to a sync.
 - `ocsp_address` (String) The address of the OCSP responder to which to connect. Set to empty string to disable OCSP.
@@ -208,7 +207,6 @@ resource "powerscale_synciq_policy" "policy_when_source_modified" {
 - `restrict_target_network` (Boolean) If you specify true, and you specify a SmartConnect zone in the "target_host" field, replication policies will connect only to nodes in the specified SmartConnect zone.  If you specify false, replication policies are not restricted to specific nodes on the target cluster.
 - `rpo_alert` (Number) If `schedule` is set to a time/date, an alert is created if the specified RPO for this policy is exceeded. The default value is 0, which will not generate RPO alerts.
 - `schedule` (String) The schedule on which new jobs will be run for this policy.
-- `service_policy` (Boolean) If true, this is a service replication policy.
 - `skip_lookup` (Boolean) Skip DNS lookup of target IPs.
 - `skip_when_source_unmodified` (Boolean) If true and `schedule` is set to a time/date, the policy will not run if no changes have been made to the contents of the source directory since the last job successfully completed.
 - `snapshot_sync_existing` (Boolean) If true, snapshot-triggered syncs will include snapshots taken before policy creation time (requires --schedule when-snapshot-taken).

--- a/powerscale/helper/synciq_rule_schema_datasource.go
+++ b/powerscale/helper/synciq_rule_schema_datasource.go
@@ -28,6 +28,8 @@ import (
 // SyncIQRuleDataSourceSchema defines the schema for the data source.
 func SyncIQRuleDataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
+		MarkdownDescription: "This datasource is used to query the existing SyncIQ Replication Rules from PowerScale array.",
+		Description:         "This datasource is used to query the existing SyncIQ Replication Rules from PowerScale array.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Optional:            true,

--- a/powerscale/models/synciq_policy.go
+++ b/powerscale/models/synciq_policy.go
@@ -150,7 +150,6 @@ type SynciqpolicyResourceModel struct {
 	ForceInterface                    types.Bool   `tfsdk:"force_interface"`
 	IgnoreRecursiveQuota              types.Bool   `tfsdk:"ignore_recursive_quota"`
 	JobDelay                          types.Int64  `tfsdk:"job_delay"`
-	LinkedServicePolicies             types.List   `tfsdk:"linked_service_policies"`
 	LogLevel                          types.String `tfsdk:"log_level"`
 	LogRemovedFiles                   types.Bool   `tfsdk:"log_removed_files"`
 	Name                              types.String `tfsdk:"name"`
@@ -163,7 +162,6 @@ type SynciqpolicyResourceModel struct {
 	RestrictTargetNetwork             types.Bool   `tfsdk:"restrict_target_network"`
 	RpoAlert                          types.Int64  `tfsdk:"rpo_alert"`
 	Schedule                          types.String `tfsdk:"schedule"`
-	ServicePolicy                     types.Bool   `tfsdk:"service_policy"`
 	SkipLookup                        types.Bool   `tfsdk:"skip_lookup"`
 	SkipWhenSourceUnmodified          types.Bool   `tfsdk:"skip_when_source_unmodified"`
 	SnapshotSyncExisting              types.Bool   `tfsdk:"snapshot_sync_existing"`

--- a/powerscale/provider/synciq_policy_resource_schema.go
+++ b/powerscale/provider/synciq_policy_resource_schema.go
@@ -37,6 +37,10 @@ import (
 // Schema implements resource.Resource.
 func (s *synciqPolicyResource) Schema(ctx context.Context, res resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		MarkdownDescription: "This resource is used to manage the SyncIQ Replication Policy entity of PowerScale Array. " +
+			"We can Create, Read, Update and Delete the SyncIQ Replication Policy using this resource. We can also import existing SyncIQ Replication Policy from PowerScale array.",
+		Description: "This resource is used to manage the SyncIQ Replication Policy entity of PowerScale Array. " +
+			"We can Create, Read, Update and Delete the SyncIQ Replication Policy using this resource. We can also import existing SyncIQ Replication Policy from PowerScale array.",
 		Attributes: map[string]schema.Attribute{
 			"accelerated_failback": schema.BoolAttribute{
 				Optional:            true,
@@ -287,19 +291,6 @@ func (s *synciqPolicyResource) Schema(ctx context.Context, res resource.SchemaRe
 				Description:         "If `schedule` is set to `when-source-modified`, the duration to wait after a modification is made before starting a job (default is 0 seconds).",
 				MarkdownDescription: "If `schedule` is set to `when-source-modified`, the duration to wait after a modification is made before starting a job (default is 0 seconds).",
 			},
-			"linked_service_policies": schema.ListAttribute{
-				Optional:            true,
-				Computed:            true,
-				Description:         "A list of service replication policies that this data replication policy will be associated with.",
-				MarkdownDescription: "A list of service replication policies that this data replication policy will be associated with.",
-				ElementType:         types.StringType,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
-				},
-				Validators: []validator.List{
-					listvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
-				},
-			},
 			"log_level": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -403,12 +394,6 @@ func (s *synciqPolicyResource) Schema(ctx context.Context, res resource.SchemaRe
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-			},
-			"service_policy": schema.BoolAttribute{
-				Optional:            true,
-				Computed:            true,
-				Description:         "If true, this is a service replication policy.",
-				MarkdownDescription: "If true, this is a service replication policy.",
 			},
 			"skip_lookup": schema.BoolAttribute{
 				Optional:            true,


### PR DESCRIPTION
Removing these attributes because the service-policy related attributes do not work on this API.

Also adding descriptions to synciq policy res and synciq rule ds

Tested via

```
Running tool: /usr/local/go/bin/go test -timeout 5h -coverprofile=/tmp/vscode-gowFGuRU/go-code-cover -run ^TestAccSynciqPolicyResource$ terraform-provider-powerscale/powerscale/provider -v


Mockey check failed, please add -gcflags="all=-N -l".
(Set env MOCKEY_CHECK_GCFLAGS=false to disable gcflags check)

=== RUN   TestAccSynciqPolicyResource
--- PASS: TestAccSynciqPolicyResource (11.97s)
PASS
coverage: 5.2% of statements
ok  	terraform-provider-powerscale/powerscale/provider	11.996s	coverage: 5.2% of statements
```