### PR TITLE
Added fix for s3 bucket and smb share datasources filter bug

### DIFF
--- a/powerscale/provider/s3_bucket_datasource.go
+++ b/powerscale/provider/s3_bucket_datasource.go
@@ -25,8 +25,10 @@ import (
 	"terraform-provider-powerscale/powerscale/helper"
 	"terraform-provider-powerscale/powerscale/models"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -170,11 +172,17 @@ func (d *S3BucketDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 						Description:         "Specifies which access zone to use.",
 						MarkdownDescription: "Specifies which access zone to use.",
 						Optional:            true,
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+						},
 					},
 					"owner": schema.StringAttribute{
 						Description:         "Specifies the name of the owner.",
 						MarkdownDescription: "Specifies the name of the owner.",
 						Optional:            true,
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+						},
 					},
 				},
 			},
@@ -216,6 +224,10 @@ func (d *S3BucketDataSource) Read(ctx context.Context, req datasource.ReadReques
 			return
 		}
 		filteredBuckets = append(filteredBuckets, entity)
+	}
+
+	if filteredBuckets == nil {
+		resp.Diagnostics.AddError("Error reading s3 buckets", "No buckets found with the specified filter(s)")
 	}
 
 	state.ID = types.StringValue("s3_bucket_datasource")


### PR DESCRIPTION
<!--
Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description
Added filter validation for invalid and empty cases in S3 Bucket and SMB Share Datasources

##### RESOURCE OR DATASOURCE NAME
S3 Bucket Datasource
SMB Share Datasource

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests