### PR TITLE
Snapshot Schedule Import Retention Time

### DIFF
--- a/docs/resources/snapshot_schedule.md
+++ b/docs/resources/snapshot_schedule.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2023-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Mozilla Public License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ This resource is used to manage the Snapshot Schedule entity on PowerScale array
 
 ```terraform
 /*
-Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) 2023-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Mozilla Public License Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ resource "powerscale_snapshot_schedule" "snap_schedule" {
   # path = "/ifs/tfacc_test"
 
   # Time value in String for which snapshots created by this snapshot schedule should be retained. Values supported are of format : 
-  # "Never Expires, x Seconds(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Month(s), x Year(s) where x can be any integer value.
+  # "Never Expires, x Second(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Year(s) where x can be any integer value.
   # Default set to : "1 Week(s)"
   # retention_time = "3 Hour(s)" 
 
@@ -102,12 +102,11 @@ resource "powerscale_snapshot_schedule" "snap_schedule" {
 ### Optional
 
 - `alias` (String) Alias name to create for each snapshot.
-- `duration` (Number) Time in seconds added to creation time to construction expiration time.
 - `next_run` (Number) Unix Epoch time of next snapshot to be created.
 - `next_snapshot` (String) Formatted name (see pattern) of next snapshot to be created
 - `path` (String) The /ifs path snapshotted.
 - `pattern` (String) Pattern expanded with strftime to create snapshot names.Some sample values for pattern are: 'snap-%F' would yield snap-1984-03-20 , 'backup-%FT%T' would yield backup-1984-03-20T22:30:00
-- `retention_time` (String) Time value in String for which snapshots created by this snapshot schedule should be retained.Values supported are of format : Never Expires, x Seconds(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Month(s), x Year(s) where x can be any integer value
+- `retention_time` (String) Time value in String for which snapshots created by this snapshot schedule should be retained.Values supported are of format : Never Expires, x Second(s), x Minute(s), x Hour(s), x Day(s), x Week(s), x Year(s) where x can be any integer value
 - `schedule` (String) The isidate-compatible natural language description of the schedule. It specifies the frequency of the schedule. You can specify this as combination of <interval> and <frequency> where each of them can be defined as: 
 				<interval>:
 					*Every [ ( other | <integer> ) ] ( weekday | day | week [ on <day>] | month [ on the <integer> ] | <day>[, ...] [ of every [ ( other | <integer> ) ] week ] | The last (day | weekday | <day>) of every [ (other | <integer>) ] month | The <integer> (weekday | <day>) of every [ (other | <integer>) ] month | The <integer> of every [ (other | <integer>) ] month | Yearly on <month> <integer> | Yearly on the (last | <integer>) [ weekday | <day> ] of <month>
@@ -130,7 +129,7 @@ Unless specified otherwise, all fields of this resource can be updated.
 Import is supported using the following syntax:
 
 ```shell
-# Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2023-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 # Licensed under the Mozilla Public License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/resources/powerscale_snapshot_schedule/import.sh
+++ b/examples/resources/powerscale_snapshot_schedule/import.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2023-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 # Licensed under the Mozilla Public License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/resources/powerscale_snapshot_schedule/provider.tf
+++ b/examples/resources/powerscale_snapshot_schedule/provider.tf
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) 2023-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Mozilla Public License Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/resources/powerscale_snapshot_schedule/resource.tf
+++ b/examples/resources/powerscale_snapshot_schedule/resource.tf
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) 2023-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Mozilla Public License Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ resource "powerscale_snapshot_schedule" "snap_schedule" {
   # path = "/ifs/tfacc_test"
 
   # Time value in String for which snapshots created by this snapshot schedule should be retained. Values supported are of format : 
-  # "Never Expires, x Seconds(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Month(s), x Year(s) where x can be any integer value.
+  # "Never Expires, x Second(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Year(s) where x can be any integer value.
   # Default set to : "1 Week(s)"
   # retention_time = "3 Hour(s)" 
 

--- a/powerscale/models/snapshot_schedule.go
+++ b/powerscale/models/snapshot_schedule.go
@@ -69,8 +69,6 @@ type SnapshotScheduleFilter struct {
 type SnapshotScheduleResource struct {
 	// Alias name to create for each snapshot.
 	Alias types.String `tfsdk:"alias"`
-	// Time in seconds added to creation time to construction expiration time.
-	Duration types.Int64 `tfsdk:"duration"`
 	// The system ID given to the schedule.
 	ID types.String `tfsdk:"id"`
 	// The schedule name.
@@ -85,6 +83,6 @@ type SnapshotScheduleResource struct {
 	Pattern types.String `tfsdk:"pattern"`
 	// The isidate compatible natural language description of the schedule.
 	Schedule types.String `tfsdk:"schedule"`
-	//Time value in String for which snapshots created by this snapshot schedule should be retained. Values supported are of format : "Never Expires, x Seconds(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Month(s), x Year(s) where x can be any integer value.
+	//Time value in String for which snapshots created by this snapshot schedule should be retained. Values supported are of format : "Never Expires, x Seconds(s), x Minute(s), x Hour(s), x Day(s), x Week(s), x Year(s) where x can be any integer value.
 	RetentionTime types.String `tfsdk:"retention_time"`
 }

--- a/powerscale/provider/snapshot_schedule_resource.go
+++ b/powerscale/provider/snapshot_schedule_resource.go
@@ -77,15 +77,9 @@ func (r *SnapshotScheduleResource) Schema(ctx context.Context, req resource.Sche
 					stringvalidator.LengthAtMost(255),
 				},
 			},
-			"duration": schema.Int64Attribute{
-				Description:         "Time in seconds added to creation time to construction expiration time.",
-				MarkdownDescription: "Time in seconds added to creation time to construction expiration time.",
-				Computed:            true,
-				Optional:            true,
-			},
 			"retention_time": schema.StringAttribute{
-				Description:         "Time value in String for which snapshots created by this snapshot schedule should be retained.Values supported are of format : " + "Never Expires, x Seconds(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Month(s), x Year(s) where x can be any integer value",
-				MarkdownDescription: "Time value in String for which snapshots created by this snapshot schedule should be retained.Values supported are of format : " + "Never Expires, x Seconds(s), x Minute(s), x Hour(s), x Week(s), x Day(s), x Month(s), x Year(s) where x can be any integer value",
+				Description:         "Time value in String for which snapshots created by this snapshot schedule should be retained.Values supported are of format : " + "Never Expires, x Second(s), x Minute(s), x Hour(s), x Day(s), x Week(s), x Year(s) where x can be any integer value",
+				MarkdownDescription: "Time value in String for which snapshots created by this snapshot schedule should be retained.Values supported are of format : " + "Never Expires, x Second(s), x Minute(s), x Hour(s), x Day(s), x Week(s), x Year(s) where x can be any integer value",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("1 Week(s)"),
@@ -253,12 +247,12 @@ func (r SnapshotScheduleResource) Read(ctx context.Context, request resource.Rea
 		return
 	}
 	state := models.SnapshotScheduleResource{}
+	state.RetentionTime = plan.RetentionTime
 	err = helper.SnapshotScheduleMapper(ctx, result, &state)
 	if err != nil {
 		response.Diagnostics.AddError(constants.ReadSnapshotScheduleErrorMessage+" with error: ", err.Error())
 		return
 	}
-	state.RetentionTime = plan.RetentionTime
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 	tflog.Info(ctx, "Read Snapshot Schedule  completed")
 }

--- a/powerscale/provider/snapshot_schedule_resource_test.go
+++ b/powerscale/provider/snapshot_schedule_resource_test.go
@@ -44,7 +44,7 @@ func TestAccSnapshotScheduleResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "path", "/ifs/tfacc_file_system_test"),
 					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "name", "tfacc_snap_schedule_test"),
-					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "duration", "10800"),
+					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "retention_time", "3 Hour(s)"),
 					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "alias", "test_alias"),
 				),
 			},
@@ -58,12 +58,12 @@ func TestAccSnapshotScheduleResource(t *testing.T) {
 					return nil
 				},
 			},
-			// Update name, path ,alias and duration then do Read testing
+			// Update name, path ,alias then do Read testing
 			{
 				Config: ProviderConfig + SnapshotScheduleUpdateResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "path", "/ifs/tfacc_test"),
-					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "duration", "14400"),
+					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "retention_time", "4 Hour(s)"),
 					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "alias", "test_alias_updated"),
 					resource.TestCheckResourceAttr(snapshotScheduleResourceName, "name", "tfacc_snap_schedule_update"),
 				),


### PR DESCRIPTION
<!--
Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description
- Remove the "duration" field instead just use "retention_time" and convert from `duration` to `retention_time` during import.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/dell-terraform-providers/issues/19
| |

# ISSUE TYPE
- Bugfix Pull Request 

##### RESOURCE OR DATASOURCE NAME
Snapshot Schedule 

##### OUTPUT
Import State successful with `retention_time` set 
```
 TF_LOG=INFO terraform import powerscale_snapshot_schedule.snap_schedule 1090
2025-02-07T12:56:12.635-0500 [WARN]  Provider "registry.terraform.io/dell/powerscale" produced an unexpected new value for powerscale_snapshot_schedule.snap_schedule during refresh.
      - .next_snapshot: was null, but now cty.StringVal("ScheduleName_duration_2025-02-08_11:00")
      - .path: was null, but now cty.StringVal("/ifs")
      - .name: was null, but now cty.StringVal("Snapshot schedule 413573952")
      - .next_run: was null, but now cty.NumberIntVal(1.7389926e+09)
      - .schedule: was null, but now cty.StringVal("every 1 days at 11:00 AM")
      - .pattern: was null, but now cty.StringVal("ScheduleName_duration_%Y-%m-%d_%H:%M")
      - .retention_time: was null, but now cty.StringVal("6 Day(s)")
2025-02-07T12:56:12.642-0500 [INFO]  Writing state output to:

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Acceptance tests

## Coverage still above 80%
![image](https://github.com/user-attachments/assets/bf20814c-33f4-428b-baf6-05b25c07f253)
