### PR TITLE
 Add custom type to address case insensitive attributes

### DIFF
--- a/powerscale/helper/resource_helper.go
+++ b/powerscale/helper/resource_helper.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"terraform-provider-powerscale/powerscale/models"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -68,7 +69,6 @@ func CopyFieldsToNonNestedModel(ctx context.Context, source, destination interfa
 			"sourceFieldTag":  sourceFieldTag,
 			"sourceFieldKind": sourceValue.Field(i).Kind().String(),
 		})
-
 		sourceField := sourceValue.Field(i)
 		if sourceField.Kind() == reflect.Ptr {
 			sourceField = sourceField.Elem()
@@ -78,6 +78,7 @@ func CopyFieldsToNonNestedModel(ctx context.Context, source, destination interfa
 		if structType.Kind() == reflect.Ptr {
 			structType = structType.Elem()
 		}
+
 		// For zero value (nil), the object still need to pass type information into it
 		if !sourceField.IsValid() {
 			destinationField = getFieldByTfTag(destinationValue.Elem(), sourceFieldTag)
@@ -156,6 +157,11 @@ func CopyFieldsToNonNestedModel(ctx context.Context, source, destination interfa
 			}
 			if destinationField.Type() == reflect.TypeOf(destinationFieldValue) {
 				destinationField.Set(reflect.ValueOf(destinationFieldValue))
+			} else if destinationField.Type().String() == "models.CaseInsensitiveStringValue" {
+				tflog.Debug(ctx, "setting destination field to case insensitive string", map[string]interface{}{
+					"sourceField": sourceField.String(),
+				})
+				destinationField.Set(reflect.ValueOf(models.CaseInsensitiveStringValue{StringValue: types.StringValue(sourceField.String())}))
 			}
 		}
 	}

--- a/powerscale/models/case_insensitive_type.go
+++ b/powerscale/models/case_insensitive_type.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://mozilla.org/MPL/2.0/
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// Ensure the implementation satisfies the expected interfaces
+package models
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ basetypes.StringTypable = (*CaseInsensitiveStringType)(nil)
+
+type CaseInsensitiveStringType struct {
+	basetypes.StringType
+}
+
+// Equal checks if the given attribute type is equal to the current type.
+//
+// It takes an attribute type as a parameter.
+// Returns a boolean indicating if the given type is equal to the current type.
+func (t CaseInsensitiveStringType) Equal(o attr.Type) bool {
+	other, ok := o.(CaseInsensitiveStringType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+// String returns the string representation of the CaseInsensitiveStringType.
+//
+// It takes no parameters.
+// Returns a string.
+func (t CaseInsensitiveStringType) String() string {
+	return "customtypes.CaseInsensitiveStringType"
+}
+
+// ValueFromString converts a basetypes.StringValue to a CaseInsensitiveStringValue.
+//
+// ctx is the context.Context.
+// in is the input basetypes.StringValue.
+// Returns a basetypes.StringValuable and a diag.Diagnostics.
+func (t CaseInsensitiveStringType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	// CaseInsensitiveStringValue defined in the value type section
+	value := CaseInsensitiveStringValue{
+		StringValue: in,
+	}
+
+	return value, nil
+}
+
+// ValueFromTerraform converts a tftypes.Value to an attr.Value.
+//
+// ctx is the context.Context.
+// in is the tftypes.Value to convert.
+// Returns an attr.Value and an error.
+func (t CaseInsensitiveStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+// Validate validates the given tftypes.Value.
+//
+// ctx is the context.Context.
+// in is the tftypes.Value to validate.
+// path is the path.Path.
+// Returns diag.Diagnostics.
+func (t CaseInsensitiveStringType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if in.Type() == nil {
+		return diags
+	}
+
+	return diags
+}
+
+// ValueType returns the value type of the CaseInsensitiveStringType.
+//
+// ctx is the context.Context.
+// Returns a CaseInsensitiveStringValue.
+func (t CaseInsensitiveStringType) ValueType(ctx context.Context) attr.Value {
+	return CaseInsensitiveStringValue{}
+}

--- a/powerscale/models/case_insensitive_value.go
+++ b/powerscale/models/case_insensitive_value.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://mozilla.org/MPL/2.0/
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// Ensure the implementation satisfies the expected interfaces
+package models
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure the implementation satisfies the expected interfaces
+var (
+	_ basetypes.StringValuableWithSemanticEquals = (*CaseInsensitiveStringValue)(nil)
+)
+
+type CaseInsensitiveStringValue struct {
+	basetypes.StringValue
+}
+
+// StringSemanticEquals checks the semantic equality of two CaseInsensitiveStringValue objects.
+//
+// ctx is the context.Context.
+// newValuable is the basetypes.StringValuable to compare.
+// Returns a boolean indicating if the values are equal and a diag.Diagnostics.
+func (v CaseInsensitiveStringValue) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	other, ok := newValuable.(CaseInsensitiveStringValue)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+	tflog.Debug(ctx, "CaseInsensitiveStringValue.StringSemanticEquals", map[string]interface{}{
+		"other": other.StringValue.ValueString(), "current": v.StringValue.ValueString(), "equal": strings.EqualFold(v.StringValue.ValueString(), other.StringValue.ValueString())})
+
+	results := false
+	if strings.EqualFold(v.StringValue.ValueString(), other.StringValue.ValueString()) {
+		results = true
+		v = other
+	}
+	return results, diags
+}
+
+// Type returns the type of the CaseInsensitiveStringValue.
+//
+// ctx is the context.Context.
+// Returns a CaseInsensitiveStringType.
+func (v CaseInsensitiveStringValue) Type(ctx context.Context) attr.Type {
+	return CaseInsensitiveStringType{}
+}
+
+// ValueString returns the value of the CaseInsensitiveStringValue.
+//
+// ctx is the context.Context.
+// Returns a string.
+func (v CaseInsensitiveStringValue) ValueString() string {
+	return v.StringValue.ValueString()
+}
+
+// String returns the value of the CaseInsensitiveStringValue.
+//
+// ctx is the context.Context.
+// Returns a string.
+func (v CaseInsensitiveStringValue) String() string {
+	return v.StringValue.ValueString()
+}
+
+// ValueFromTerraform converts a tftypes.Value to an attr.Value.
+//
+// ctx is the context.Context.
+// in is the tftypes.Value to convert.
+// Returns an attr.Value and an error.
+func (v CaseInsensitiveStringValue) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if in.IsNull() {
+		return CaseInsensitiveStringValue{basetypes.NewStringNull()}, diags
+	}
+
+	var value string
+	err := in.As(&value)
+	if err != nil {
+		diags.AddError("Error converting value", err.Error())
+		return nil, diags
+	}
+
+	return CaseInsensitiveStringValue{basetypes.NewStringValue(value)}, diags
+}
+
+// Implement the ValueType method.
+
+// ValueType returns the value type of the CaseInsensitiveStringValue.
+func (v CaseInsensitiveStringValue) ValueType(_ context.Context) attr.Value {
+	return CaseInsensitiveStringValue{}
+}
+
+// NewCaseInsensitiveStringNull creates an CaseInsensitiveStringValue with a null value. Determine whether the value is null via IsNull method.
+func NewCaseInsensitiveStringNull() CaseInsensitiveStringValue {
+	return CaseInsensitiveStringValue{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+// NewCaseInsensitiveStringUnknown creates an CaseInsensitiveStringValue with an unknown value. Determine whether the value is unknown via IsUnknown method.
+func NewCaseInsensitiveStringUnknown() CaseInsensitiveStringValue {
+	return CaseInsensitiveStringValue{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+// NewCaseInsensitiveStringValue creates an CaseInsensitiveStringValue with a known value. Access the value via ValueString method.
+func NewCaseInsensitiveStringValue(value string) CaseInsensitiveStringValue {
+	return CaseInsensitiveStringValue{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+// NewIPv4AddressPointerValue creates an CaseInsensitiveStringValue with a null value if nil or a known value. Access the value via ValueStringPointer method.
+func NewCaseInsensitiveStringPointerValue(value *string) CaseInsensitiveStringValue {
+	return CaseInsensitiveStringValue{
+		StringValue: basetypes.NewStringPointerValue(value),
+	}
+}

--- a/powerscale/models/nfs_export.go
+++ b/powerscale/models/nfs_export.go
@@ -17,7 +17,9 @@ limitations under the License.
 
 package models
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 // NfsExportResource Specifies configuration values for NFS exports.
 type NfsExportResource struct {
@@ -138,7 +140,7 @@ type NfsExportResource struct {
 	// Specifies the stability disposition returned when an NFSv3+ unstable write is processed.
 	WriteUnstableReply types.String `tfsdk:"write_unstable_reply"`
 	// Specifies the zone in which the export is valid.
-	Zone types.String `tfsdk:"zone"`
+	Zone CaseInsensitiveStringValue `tfsdk:"zone"`
 }
 
 // NfsExportDatasource holds nfs exports datasource schema attribute details.


### PR DESCRIPTION
<!--
Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description
 Add custom type to address case insensitive attributes. This PR addresses one attribute (zone) from nfs export resource, 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### RESOURCE OR DATASOURCE NAME
<!--- Write the short name of the resource or datasource below -->
powerscale_nfs_export
##### OUTPUT
<!--- Paste the functionality test result below -->
```paste below
17 scenarios ([32m17 passed[0m)
56 steps ([32m56 passed[0m)
1m28.429153346s]]></system-out>

```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
eg. AccessZone created with name AccessZone, if we pass zone in  
resource "powerscale_nfs_export" "nfsTestExport" {
  # Required path for creating
  for_each = toset(var.nfs_export_paths)

  paths = [each.value]
  zone = "accessZone"
  clients = [""]
  root_clients = [""]
 description = ""
}
it gives error as array accepts the zone but there is mismatch in returned values
produced an unexpected new value: .zone: was
‚ cty.StringVal("accessZone"), but now cty.StringVal("AccessZone").

Fix will allow this without error as both are treated as same. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 80% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Unit tests
- [X] Acceptance tests