### PR TITLE
fix:(auth) environment variable authentication

### DIFF
--- a/powerscale/provider/provider.go
+++ b/powerscale/provider/provider.go
@@ -170,8 +170,8 @@ func (p *PscaleProvider) Configure(ctx context.Context, req provider.ConfigureRe
 				"Unable to find username",
 				"Username cannot be an empty/unknown string",
 			)
+			return
 		}
-		return
 	}
 
 	if data.Password.IsUnknown() || data.Password.ValueString() == "" {


### PR DESCRIPTION
<!--
Copyright (c) 2023-2024 Dell Inc., or its subsidiaries. All Rights Reserved.

Licensed under the Mozilla Public License Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://mozilla.org/MPL/2.0/


Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description
This PR is a bugfix for allowing users to use environment variables to provide the powerscale username while using the powerscale provider. After this PR is approved and merged users should be able to provide the POWERSCALE_USERNAME
environment variable to configure the powerscale provider to authenticate against the target powerscale endpoint.


# ISSUE TYPE
- Bugfix Pull Request

##### RESOURCE OR DATASOURCE NAME
Provider Configuration

##### ADDITIONAL INFORMATION
An improperly placed return statement within the provider configuration block caused the below error message any time an environment variable was used to supply powerscale username:

```
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin6.(*GRPCProvider).PlanResourceChange call. The plugin logs may
│ contain more details.
╵
Stack trace from the terraform-provider-powerscale_v1.8.0 plugin:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19132ad]
goroutine 36 [running]:
terraform-provider-powerscale/powerscale/helper.GetNetworkPools({0x2710da8?, 0xc000613530?}, 0xc000613530?, {{0x0, {0x0, 0x0}}, {0x0, 0x0, 0x0}, 0x0})
	terraform-provider-powerscale/powerscale/helper/network_pool_helper.go:29 +0x2d
terraform-provider-powerscale/powerscale/provider.(*NetworkPoolDataSource).Read(0xc0003c6590, {0x2710da8, 0xc000613530}, {{{{0x2716e10, 0xc000612c30}, {0x2104800, 0xc0006126f0}}, {0x271faf0, 0xc0003a4100}}, {{{0x0, ...}, ...}, ...}, ...}, ...)
	terraform-provider-powerscale/powerscale/provider/network_pool_datasource.go:327 +0x19c
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ReadDataSource(0xc000130488, {0x2710da8, 0xc000613530}, 0xc00042e5c0, 0xc000017600)
	github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/server_readdatasource.go:103 +0x76f
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ReadDataSource(0xc000130488, {0x2710da8?, 0xc00035cd80?}, 0xc00035c540)
	github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/proto6server/server_readdatasource.go:55 +0x389
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ReadDataSource(0xc0001340a0, {0x2710da8?, 0xc000273560?}, 0xc00018a870)
	github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/tf6server/server.go:688 +0x26a
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ReadDataSource_Handler({0x234c1e0, 0xc0001340a0}, {0x2710da8, 0xc000273560}, 0xc000410a80, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:665 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00016c000, {0x2710da8, 0xc0002734d0}, 0xc00035a240, 0xc000125b90, 0x3bed760, 0x0)
	google.golang.org/grpc@v1.71.0/server.go:1405 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc00016c000, {0x27119c0, 0xc0001dd6c0}, 0xc00035a240)
	google.golang.org/grpc@v1.71.0/server.go:1815 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.71.0/server.go:1035 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 12
	google.golang.org/grpc@v1.71.0/server.go:1046 +0x11d
Error: The terraform-provider-powerscale_v1.8.0 plugin crashed!
This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.

```

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility