### PR TITLE
fix(helper): handle slice of primitives to Terraform types in CopyFields

### DIFF
--- a/powerscale/helper/helper.go
+++ b/powerscale/helper/helper.go
@@ -124,6 +124,39 @@ func CopyFields(ctx context.Context, source, destination interface{}) error {
 							}
 							slice.Index(index).Set(reflect.ValueOf(newDes))
 						case reflect.Struct:
+							// Check if destination is a Terraform primitive type wrapper
+							destTypeName := v.Type().String()
+							srcKind := value.Kind()
+							if srcKind == reflect.Ptr {
+								if value.IsNil() {
+									continue
+								}
+								srcKind = value.Elem().Kind()
+								value = value.Elem()
+							}
+							// Handle primitive source to Terraform type destination
+							if srcKind == reflect.Int || srcKind == reflect.Int8 || srcKind == reflect.Int16 || srcKind == reflect.Int32 || srcKind == reflect.Int64 {
+								if strings.Contains(destTypeName, "Int64") {
+									slice.Index(index).Set(reflect.ValueOf(types.Int64Value(value.Int())))
+									continue
+								}
+							} else if srcKind == reflect.Uint || srcKind == reflect.Uint8 || srcKind == reflect.Uint16 || srcKind == reflect.Uint32 || srcKind == reflect.Uint64 {
+								if strings.Contains(destTypeName, "Int64") {
+									slice.Index(index).Set(reflect.ValueOf(types.Int64Value(int64(value.Uint()))))
+									continue
+								}
+							} else if srcKind == reflect.String {
+								if strings.Contains(destTypeName, "String") {
+									slice.Index(index).Set(reflect.ValueOf(types.StringValue(value.String())))
+									continue
+								}
+							} else if srcKind == reflect.Bool {
+								if strings.Contains(destTypeName, "Bool") {
+									slice.Index(index).Set(reflect.ValueOf(types.BoolValue(value.Bool())))
+									continue
+								}
+							}
+							// Default: struct-to-struct copy
 							newDes := reflect.New(v.Type()).Interface()
 							err := CopyFields(ctx, value.Interface(), newDes)
 							if err != nil {


### PR DESCRIPTION
## Summary

Fix `CopyFields` function failing with "source is not a struct" error when copying slices of Go primitives to slices of Terraform types.

## Problem

When a Go struct contains a slice of primitives (e.g., `[]int32`) and the destination Terraform model expects a slice of Terraform types (e.g., `[]types.Int64`), `CopyFields` failed because:

1. `types.Int64`, `types.String`, `types.Bool` are Go structs
2. The code detected `reflect.Struct` and attempted recursive `CopyFields`
3. But the source element (e.g., `int32`) is not a struct, causing the error

## Solution

Added detection for primitive source types when the destination is a Terraform type wrapper:
- `int*` / `uint*` → `types.Int64`
- `string` → `types.String`
- `bool` → `types.Bool`

Performs direct conversion instead of recursive `CopyFields` for these cases.

## Affected Resources

- `powerscale_networkpool` data source (ScSuspendedNodes: `[]int32` → `[]types.Int64`)
- Potentially other resources with similar slice mappings

## Test plan

- [x] Tested with OneFS 9.7.1.5 (LTS2024) cluster
- [x] `terraform plan` and `terraform output -json` succeed for networkpool data source
- [x] Network pools correctly display all fields including `nfsv3_rroce_only`

🤖 Generated with [Claude Code](https://claude.ai/code)