### PR TITLE
fix(ECS02C-1143): ECS02C-1143

### DIFF
--- a/powerscale/provider/ads_provider_resource.go
+++ b/powerscale/provider/ads_provider_resource.go
@@ -104,7 +104,6 @@ func (r *AdsProviderResource) Schema(ctx context.Context, req resource.SchemaReq
 			"controller_time": schema.Int64Attribute{
 				Description:         "Specifies the current time for the domain controllers.",
 				MarkdownDescription: "Specifies the current time for the domain controllers.",
-				Optional:            true,
 				Computed:            true,
 			},
 			"create_home_directory": schema.BoolAttribute{


### PR DESCRIPTION
## Defect: [ECS02C-1143](https://jira.cec.lab.emc.com/browse/ECS02C-1143)

**Summary:** ECS02C-1143

## Devin Analysis & Fix

## Summary

ROOT CAUSE: The `controller_time` attribute was marked as both `Optional` and `Computed` in the schema, causing Terraform to project the current value into plans, which then differs from the live timestamp read back after apply, triggering an inconsistency error.

FIX SUMMARY: Removed `Optional: true` from the `controller_time` schema attribute in `powerscale/provider/ads_provider_resource.go`, making it `Computed` only. This prevents Terraform from projecting the value into plans and allows the post-apply consistency check to accept any live timestamp value.

FILES CHANGED: powerscale/provider/ads_provider_resource.go

TEST RESULT: pass (unit tests passed; acceptance tests skipped due to missing environment variables for PowerScale array access)

CONFIDENCE: high

## Test Checklist
- [ ] Unit tests pass
- [ ] Integration / regression tests pass
- [ ] Defect is no longer reproducible
- [ ] No unrelated changes included