### PR TITLE
fix(ECS02C-1143): [GitHub] [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift

### DIFF
--- a/powerscale/provider/ads_provider_resource.go
+++ b/powerscale/provider/ads_provider_resource.go
@@ -104,7 +104,6 @@ func (r *AdsProviderResource) Schema(ctx context.Context, req resource.SchemaReq
 			"controller_time": schema.Int64Attribute{
 				Description:         "Specifies the current time for the domain controllers.",
 				MarkdownDescription: "Specifies the current time for the domain controllers.",
-				Optional:            true,
 				Computed:            true,
 			},
 			"create_home_directory": schema.BoolAttribute{


### PR DESCRIPTION
## Defect: [ECS02C-1143](https://jira.cec.lab.emc.com/browse/ECS02C-1143)

**Summary:** [GitHub] [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift

## Devin Analysis & Fix

## Summary

ROOT CAUSE: The `controller_time` attribute was marked as both Optional and Computed, causing Terraform to project the current value into the plan, which then differs from the value read back after apply due to clock drift, resulting in an inconsistency error.

FIX SUMMARY: Removed `Optional: true` from the `controller_time` schema attribute in `powerscale/provider/ads_provider_resource.go`, making it Computed-only. This allows Terraform to always show it as "(known after apply)" and accept any value returned by the provider in the post-apply consistency check, preventing the clock drift error.

FILES CHANGED: powerscale/provider/ads_provider_resource.go

TEST RESULT: pass (code compiles successfully, static analysis passes, unit tests pass; acceptance tests require credentials which are not available in this environment)

CONFIDENCE: high

## Test Checklist
- [ ] Unit tests pass
- [ ] Integration / regression tests pass
- [ ] Defect is no longer reproducible
- [ ] No unrelated changes included