### PR TITLE
fix: [GitHub] [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift

### DIFF
--- a/powerscale/provider/ads_provider_resource.go
+++ b/powerscale/provider/ads_provider_resource.go
@@ -104,7 +104,6 @@ func (r *AdsProviderResource) Schema(ctx context.Context, req resource.SchemaReq
 			"controller_time": schema.Int64Attribute{
 				Description:         "Specifies the current time for the domain controllers.",
 				MarkdownDescription: "Specifies the current time for the domain controllers.",
-				Optional:            true,
 				Computed:            true,
 			},
 			"create_home_directory": schema.BoolAttribute{


### PR DESCRIPTION
## Fix

**Summary:** [GitHub] [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift

## Analysis & Fix

## Summary

ROOT CAUSE: The `controller_time` attribute was marked as both `Optional: true` and `Computed: true` in the schema, causing Terraform to project the current timestamp value into the plan, which then differed from the value read back after apply due to clock drift.

FIX SUMMARY: Removed `Optional: true` from the `controller_time` schema attribute in `powerscale/provider/ads_provider_resource.go`, making it Computed-only. This ensures Terraform always shows it as "(known after apply)" and accepts any value returned by the provider in the post-apply consistency check, eliminating the inconsistency error.

FILES CHANGED: powerscale/provider/ads_provider_resource.go

TEST RESULT: pass (unit tests passed, code compiles successfully, acceptance tests skipped due to missing environment variables which is expected)

CONFIDENCE: high

## Test Checklist
- [ ] Unit tests pass
- [ ] Integration / regression tests pass
- [ ] Issue is no longer reproducible
- [ ] No unrelated changes included