### PR TITLE
fix: [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift (#58)

### DIFF
--- a/powerscale/provider/ads_provider_resource.go
+++ b/powerscale/provider/ads_provider_resource.go
@@ -104,7 +104,6 @@ func (r *AdsProviderResource) Schema(ctx context.Context, req resource.SchemaReq
 			"controller_time": schema.Int64Attribute{
 				Description:         "Specifies the current time for the domain controllers.",
 				MarkdownDescription: "Specifies the current time for the domain controllers.",
-				Optional:            true,
 				Computed:            true,
 			},
 			"create_home_directory": schema.BoolAttribute{


### PR DESCRIPTION
## Fixes [#58](https://github.com/dell/dell-terraform-providers/issues/58)

**Issue:** [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift
**Reported by:** @petew-nfx

## Analysis & Fix

## Defect Resolution Summary

**ROOT CAUSE:** The `controller_time` attribute in the `powerscale_adsprovider` resource schema was incorrectly marked as both `Optional` and `Computed`, causing Terraform to expect a stable value during apply operations while the field is actually a live epoch timestamp that changes on every API read.

**FIX SUMMARY:** Removed `Optional: true` from the `controller_time` attribute definition in the schema, leaving only `Computed: true`. This change ensures that Terraform treats the field as a computed-only value that is always known after apply, preventing the "inconsistent result after apply" error when the timestamp changes between plan and apply phases.

**FILES CHANGED:** powerscale/provider/ads_provider_resource.go

**TEST RESULT:** pass (build succeeded, unit tests passed; acceptance tests skipped due to missing environment variables which is expected)

**CONFIDENCE:** high

## Test Checklist
- [ ] Unit tests pass
- [ ] Integration / regression tests pass
- [ ] Issue is no longer reproducible
- [ ] No unrelated changes included