### PR TITLE
fix: [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift (#4)

### DIFF
--- a/powerscale/provider/ads_provider_resource.go
+++ b/powerscale/provider/ads_provider_resource.go
@@ -104,7 +104,6 @@ func (r *AdsProviderResource) Schema(ctx context.Context, req resource.SchemaReq
 			"controller_time": schema.Int64Attribute{
 				Description:         "Specifies the current time for the domain controllers.",
 				MarkdownDescription: "Specifies the current time for the domain controllers.",
-				Optional:            true,
 				Computed:            true,
 			},
 			"create_home_directory": schema.BoolAttribute{


### PR DESCRIPTION
## Fixes [#4](https://github.com/trisha-dell/Github-JIRA-test/issues/4)

**Issue:** [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift
**Reported by:** @Krunal-Thakkar

## Analysis & Fix

## Summary

ROOT CAUSE: The `controller_time` attribute was marked as `Optional: true, Computed: true` in the schema, causing Terraform to project the current timestamp value into the plan during updates, which then differed from the live value read back after apply, triggering an inconsistency error.

FIX SUMMARY: Removed `Optional: true` from the `controller_time` schema attribute in `powerscale/provider/ads_provider_resource.go`, making it `Computed: true` only. This ensures Terraform treats it as a read-only value that will always be "(known after apply)" and accepts any value returned by the provider in post-apply consistency checks.

FILES CHANGED: powerscale/provider/ads_provider_resource.go

TEST RESULT: pass (unit tests passed; acceptance tests require PowerScale environment setup)

CONFIDENCE: high

## Test Checklist
- [ ] Unit tests pass
- [ ] Integration / regression tests pass
- [ ] Issue is no longer reproducible
- [ ] No unrelated changes included