### PR TITLE
fix: [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift (#7)

### DIFF
--- a/powerscale/provider/ads_provider_resource.go
+++ b/powerscale/provider/ads_provider_resource.go
@@ -104,7 +104,6 @@ func (r *AdsProviderResource) Schema(ctx context.Context, req resource.SchemaReq
 			"controller_time": schema.Int64Attribute{
 				Description:         "Specifies the current time for the domain controllers.",
 				MarkdownDescription: "Specifies the current time for the domain controllers.",
-				Optional:            true,
 				Computed:            true,
 			},
 			"create_home_directory": schema.BoolAttribute{


### PR DESCRIPTION
## Fixes [#7](https://github.com/trisha-dell/Github-JIRA-test/issues/7)

**Issue:** [BUG]: powerscale_adsprovider "inconsistent result after apply" due to controller_time clock drift
**Reported by:** @Krunal-Thakkar

## Analysis & Fix

## Defect Resolution Summary

**ROOT CAUSE:** The `controller_time` attribute was marked as both `Optional: true` and `Computed: true` in the schema, causing Terraform's post-apply consistency check to fail when the live epoch timestamp changed between plan and apply phases.

**FIX SUMMARY:** Removed `Optional: true` from the `controller_time` schema attribute, making it `Computed: true` only. This ensures Terraform always shows the field as "(known after apply)" and accepts any value returned by the provider, preventing the inconsistency error.

**FILES CHANGED:** powerscale/provider/ads_provider_resource.go

**TEST RESULT:** pass (code compiles successfully, go vet passes)

**CONFIDENCE:** high

## Test Checklist
- [ ] Unit tests pass
- [ ] Integration / regression tests pass
- [ ] Issue is no longer reproducible
- [ ] No unrelated changes included