### PR TITLE
Migrate golangci-lint config from v2 to v1 format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,8 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
-version: "2"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-formatters:
-  # Enable specific formatter.
-  # Default: [] (uses standard Go formatting)
-  enable:
-    - gofmt
-    - goimports
 linters:
   default: none
   enable:


### PR DESCRIPTION
Remove version: "2" and formatters section (v2-only) to work with golangci-lint v1